### PR TITLE
Fix texture encoding issue

### DIFF
--- a/MikuMikuLibrary.Native/TextureEncoderCore.cpp
+++ b/MikuMikuLibrary.Native/TextureEncoderCore.cpp
@@ -135,7 +135,11 @@ namespace MikuMikuLibrary::Textures::Processing
         array<SubTexture^, 2>^ subTextures = gcnew array<SubTexture^, 2>( ( int ) metadata.arraySize, ( int ) metadata.mipLevels );
         for ( size_t i = 0; i < metadata.arraySize; i++ )
         {
-            size_t index = metadata.arraySize == 6 ? cubeIndexMap[ i ] : index;
+            size_t index;
+            if (metadata.arraySize == 6)
+                index = metadata.arraySize == 6 ? cubeIndexMap[i] : index;
+            else
+                index = i;
 
             for ( size_t j = 0; j < metadata.mipLevels; j++ )
                 subTextures[ ( int ) index, ( int ) j ] = EncodeToSubTexture( *scratchImage.GetImage( j, i, 0 ), formatHint );


### PR DESCRIPTION
In release 2.0.1 an issue was created inside MikuMikuLibrary.Native/TextureEncoderCore.cpp which caused crashes when importing models. This fixes that issue