### PR TITLE
Add more ex data utilities (to/from JSON), 3ds Max material quirks

### DIFF
--- a/CliTools/DatabaseConverter/DatabaseConverter.csproj
+++ b/CliTools/DatabaseConverter/DatabaseConverter.csproj
@@ -77,6 +77,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>del "$(TargetDir)\AssimpNet.dll"</PostBuildEvent>
+    <PostBuildEvent>del "$(TargetDir)\AssimpNet.dll"
+del "$(TargetDir)\Newtonsoft.Json.dll"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/CliTools/FarcPack/FarcPack.csproj
+++ b/CliTools/FarcPack/FarcPack.csproj
@@ -76,6 +76,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>del "$(TargetDir)\AssimpNet.dll"</PostBuildEvent>
+    <PostBuildEvent>del "$(TargetDir)\AssimpNet.dll"
+del "$(TargetDir)\Newtonsoft.Json.dll"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/MikuMikuLibrary/MikuMikuLibrary.csproj
+++ b/MikuMikuLibrary/MikuMikuLibrary.csproj
@@ -50,6 +50,9 @@
     <Reference Include="AssimpNet, Version=5.0.0.0, Culture=neutral, PublicKeyToken=0d51b391f59f42a6, processorArchitecture=MSIL">
       <HintPath>..\packages\AssimpNet.5.0.0-beta1\lib\net40\AssimpNet.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
@@ -119,6 +122,7 @@
     <Compile Include="Objects\Extra\Parameters\OsageCollisionParameter.cs" />
     <Compile Include="Objects\Extra\Parameters\OsageNodeParameter.cs" />
     <Compile Include="Objects\Extra\Parameters\OsageSkinParameter.cs" />
+    <Compile Include="Objects\Processing\Json\JsonExporter.cs" />
     <Compile Include="Parameters\Extensions\ParameterTreeEx.cs" />
     <Compile Include="Parameters\Extensions\ParameterTreeWriterEx.cs" />
     <Compile Include="Parameters\ParameterTree.cs" />

--- a/MikuMikuLibrary/Objects/Extra/Blocks/ConstraintBlock.cs
+++ b/MikuMikuLibrary/Objects/Extra/Blocks/ConstraintBlock.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Numerics;
 using MikuMikuLibrary.IO;
 using MikuMikuLibrary.IO.Common;
+using Newtonsoft.Json;
 
 namespace MikuMikuLibrary.Objects.Extra.Blocks
 {
@@ -127,13 +128,14 @@ namespace MikuMikuLibrary.Objects.Extra.Blocks
         }
     }
 
+    [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public class DirectionConstraintData : IConstraintData
     {
         public ConstraintType Type => ConstraintType.Direction;
 
-        public UpVectorData UpVector { get; }
-        public Vector3 AlignAxis { get; set; }
-        public Vector3 TargetOffset { get; set; }
+        [JsonProperty] public UpVectorData UpVector { get; }
+        [JsonProperty] public Vector3 AlignAxis { get; set; }
+        [JsonProperty] public Vector3 TargetOffset { get; set; }
 
         public void Read( EndianBinaryReader reader )
         {

--- a/MikuMikuLibrary/Objects/Processing/Assimp/AssimpImporter.cs
+++ b/MikuMikuLibrary/Objects/Processing/Assimp/AssimpImporter.cs
@@ -394,6 +394,10 @@ namespace MikuMikuLibrary.Objects.Processing.Assimp
                     break;
 
                 case Ai.TextureType.Normals:
+                // 3ds max outputs FBXs with height...as normal, for some reason
+                // So as a workaround, a texturetype of Height is assigned normal
+                // Additionally, DIVA never actually *uses* height maps anyways so
+                case Ai.TextureType.Height:
                     type = MaterialTextureType.Normal;
                     flags = MaterialFlags.Normal;
                     break;
@@ -401,6 +405,15 @@ namespace MikuMikuLibrary.Objects.Processing.Assimp
                 case Ai.TextureType.Opacity:
                     type = MaterialTextureType.Transparency;
                     flags = MaterialFlags.Transparency;
+                    break;
+
+                // DIVA never actually *uses* displacement maps
+                // so as a workaround (and to alleviate headaches)
+                // Displacement can be assigned as Translucency for stuff like
+                // hair and a couple other shaders that use it
+                case Ai.TextureType.Displacement:
+                    type = MaterialTextureType.Translucency;
+                    flags = MaterialFlags.Translucency;
                     break;
 
                 case Ai.TextureType.Reflection:

--- a/MikuMikuLibrary/Objects/Processing/Json/JsonExporter.cs
+++ b/MikuMikuLibrary/Objects/Processing/Json/JsonExporter.cs
@@ -1,0 +1,14 @@
+﻿using System.IO;
+using Newtonsoft.Json;
+
+namespace MikuMikuLibrary.Objects.Processing.Json
+{
+    public static class JsonExporter
+    {
+        public static void ExportToFile(object objectToSerialize, string outputFilePath)
+        {
+            string json = JsonConvert.SerializeObject(objectToSerialize, Formatting.Indented, new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto });
+            File.WriteAllText(outputFilePath, json);
+        }
+    }
+}

--- a/MikuMikuLibrary/packages.config
+++ b/MikuMikuLibrary/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AssimpNet" version="5.0.0-beta1" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
 </packages>

--- a/MikuMikuModel/Nodes/Objects/SkinNode.cs
+++ b/MikuMikuModel/Nodes/Objects/SkinNode.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Windows.Forms;
+using System.IO;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using MikuMikuLibrary.Archives;
 using MikuMikuLibrary.Extensions;
 using MikuMikuLibrary.IO;
@@ -13,6 +16,7 @@ using MikuMikuModel.GUI.Forms;
 using MikuMikuModel.Modules;
 using MikuMikuModel.Nodes.Collections;
 using MikuMikuModel.Nodes.IO;
+using MikuMikuLibrary.Objects.Processing.Json;
 using Object = MikuMikuLibrary.Objects.Object;
 
 namespace MikuMikuModel.Nodes.Objects
@@ -105,6 +109,108 @@ namespace MikuMikuModel.Nodes.Objects
                 OnPropertyChanged( nameof( Data.Blocks ) );
             }, Keys.None, CustomHandlerFlags.ClearMementos | CustomHandlerFlags.Repopulate );
 
+            AddCustomHandler("Import ex data from Json", () =>
+            {
+                //var skin = PrompImportExData();
+                // Testing imports from Json
+                // So this should just simply be...
+                //taking this straight from keikei's part for testing. thanks oomf
+                string jsonFilePath = null;
+                // open json
+                using (var jsonFileDialog = new OpenFileDialog()
+                {
+                    Title = "Select NodeBlock json file.",
+                    Filter = "JSON files (*.json)|*.json|All files(*.*)|*.*",
+                    FilterIndex = 0,
+                    RestoreDirectory = true,
+                })
+                {
+                    if (jsonFileDialog.ShowDialog() == DialogResult.OK)
+                        jsonFilePath = jsonFileDialog.FileName;
+                }
+
+                try
+                {
+                    var placeholderImportedBlocks = File.ReadAllText(jsonFilePath);
+                    List<NodeBlock> skin = JsonConvert.DeserializeObject<List<NodeBlock>>(placeholderImportedBlocks, new JsonSerializerSettings
+                    {
+                        TypeNameHandling = TypeNameHandling.Auto,
+                        NullValueHandling = NullValueHandling.Ignore
+                    });
+                    if (skin == null)
+                        return;
+                    var nodeBlocks = skin;
+
+                    using (var itemSelectForm = new ItemSelectForm<NodeBlock>(nodeBlocks.Select(
+                        x => (x, $"{x.Signature} - {(x is OsageBlock osageBlock ? osageBlock.ExternalName : x.Name)}")).OrderBy(x => x.Item2))
+                    {
+                        Text = "Please select the blocks you want to import.",
+                        GroupBoxText = "Blocks"
+                    })
+                    {
+                        if (itemSelectForm.ShowDialog() != DialogResult.OK)
+                            return;
+
+                        var importedBlocks = skin;
+
+                        foreach (var nodeBlock in itemSelectForm.CheckedItems)
+                        {
+                            importedBlocks.AddRange(nodeBlock.TraverseParents(nodeBlocks));
+                            importedBlocks.Add(nodeBlock);
+                        }
+
+                        Data.Blocks.AddRange(importedBlocks.Distinct());
+                    }
+                }
+                catch (System.ArgumentNullException exception)
+                {
+                    return;
+                }
+                catch (System.Exception exception)
+                {
+                    MessageBox.Show(exception.Message, Program.Name, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    return;
+                }
+
+                OnPropertyChanged(nameof(Data.Blocks));
+            }, Keys.None, CustomHandlerFlags.ClearMementos | CustomHandlerFlags.Repopulate);
+
+            AddCustomHandler("Export ex data to JSON", () =>
+            {
+                var skin = PrompImportExData();
+
+                if (skin == null)
+                    return;
+
+                var nodeBlocks = skin.Blocks.OfType<NodeBlock>().ToList();
+
+                using (var itemSelectForm = new ItemSelectForm<NodeBlock>(nodeBlocks.Select(
+                    x => (x, $"{x.Signature} - {(x is OsageBlock osageBlock ? osageBlock.ExternalName : x.Name)}")).OrderBy(x => x.Item2))
+                {
+                    Text = "Please select the blocks you want to export.",
+                    GroupBoxText = "Blocks"
+                })
+                {
+                    if (itemSelectForm.ShowDialog() != DialogResult.OK)
+                        return;
+
+                    var importedBlocks = new List<NodeBlock>(skin.Blocks.Count);
+
+                    foreach (var nodeBlock in itemSelectForm.CheckedItems)
+                    {
+                        importedBlocks.AddRange(nodeBlock.TraverseParents(nodeBlocks));
+                        importedBlocks.Add(nodeBlock);
+                    }
+                    
+                    // Borrowing the Module Export Utilities to try this...
+                    // And this works!
+                    var filePath = ModuleExportUtilities.SelectModuleExport<Stream>("Select a file to export to.");
+                    JsonExporter.ExportToFile(importedBlocks.Distinct(), filePath);
+                    
+                }
+
+            }, Keys.None, CustomHandlerFlags.ClearMementos | CustomHandlerFlags.Repopulate);
+
             AddCustomHandler( "Replace ex data", () =>
             {
                 var skin = PrompImportExData();
@@ -117,6 +223,46 @@ namespace MikuMikuModel.Nodes.Objects
 
                 OnPropertyChanged( nameof( Data.Blocks ) );
             }, Keys.None, CustomHandlerFlags.ClearMementos | CustomHandlerFlags.Repopulate );
+
+            AddCustomHandler("Replace ex data from JSON", () =>
+            {
+                //taking this straight from keikei's part for testing. thanks oomf
+                string jsonFilePath = null;
+                // open json
+                using (var jsonFileDialog = new OpenFileDialog()
+                {
+                    Title = "Select NodeBlock json file.",
+                    Filter = "JSON files (*.json)|*.json|All files(*.*)|*.*",
+                    FilterIndex = 0,
+                    RestoreDirectory = true,
+                })
+                {
+                    if (jsonFileDialog.ShowDialog() == DialogResult.OK)
+                        jsonFilePath = jsonFileDialog.FileName;
+                }
+
+                try
+                {
+                    var placeholderImportedBlocks = File.ReadAllText(jsonFilePath);
+                    List<NodeBlock> importedBlocks = JsonConvert.DeserializeObject<List<NodeBlock>>(placeholderImportedBlocks, new JsonSerializerSettings
+                    {
+                        TypeNameHandling = TypeNameHandling.Auto,
+                        NullValueHandling = NullValueHandling.Ignore
+                    });
+                    Data.Blocks.Clear();
+                    Data.Blocks.AddRange(importedBlocks.Distinct());
+                }
+                catch (System.ArgumentNullException exception)
+                {
+                    return;
+                }
+                catch (System.Exception exception)
+                {
+                    MessageBox.Show(exception.Message, Program.Name, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    return;
+                }
+                OnPropertyChanged(nameof(Data.Blocks));
+            }, Keys.None, CustomHandlerFlags.ClearMementos | CustomHandlerFlags.Repopulate);
         }
 
         protected override void PopulateCore()

--- a/MikuMikuModel/Nodes/Objects/SkinNode.cs
+++ b/MikuMikuModel/Nodes/Objects/SkinNode.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Windows.Forms;
 using System.IO;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 using MikuMikuLibrary.Archives;
 using MikuMikuLibrary.Extensions;
 using MikuMikuLibrary.IO;
@@ -109,7 +108,23 @@ namespace MikuMikuModel.Nodes.Objects
                 OnPropertyChanged( nameof( Data.Blocks ) );
             }, Keys.None, CustomHandlerFlags.ClearMementos | CustomHandlerFlags.Repopulate );
 
-            AddCustomHandler("Import ex data from Json", () =>
+
+            AddCustomHandler( "Replace ex data", () =>
+            {
+                var skin = PrompImportExData();
+
+                if ( skin == null )
+                    return;
+
+                Data.Blocks.Clear();
+                Data.Blocks.AddRange( skin.Blocks );
+
+                OnPropertyChanged( nameof( Data.Blocks ) );
+            }, Keys.None, CustomHandlerFlags.ClearMementos | CustomHandlerFlags.Repopulate );
+
+            AddCustomHandlerSeparator();
+
+            AddCustomHandler("Import ex data from JSON", () =>
             {
                 //var skin = PrompImportExData();
                 // Testing imports from Json
@@ -119,7 +134,7 @@ namespace MikuMikuModel.Nodes.Objects
                 // open json
                 using (var jsonFileDialog = new OpenFileDialog()
                 {
-                    Title = "Select NodeBlock json file.",
+                    Title = "Select NodeBlock JSON file.",
                     Filter = "JSON files (*.json)|*.json|All files(*.*)|*.*",
                     FilterIndex = 0,
                     RestoreDirectory = true,
@@ -201,28 +216,15 @@ namespace MikuMikuModel.Nodes.Objects
                         importedBlocks.AddRange(nodeBlock.TraverseParents(nodeBlocks));
                         importedBlocks.Add(nodeBlock);
                     }
-                    
+
                     // Borrowing the Module Export Utilities to try this...
                     // And this works!
                     var filePath = ModuleExportUtilities.SelectModuleExport<Stream>("Select a file to export to.");
                     JsonExporter.ExportToFile(importedBlocks.Distinct(), filePath);
-                    
+
                 }
 
             }, Keys.None, CustomHandlerFlags.ClearMementos | CustomHandlerFlags.Repopulate);
-
-            AddCustomHandler( "Replace ex data", () =>
-            {
-                var skin = PrompImportExData();
-
-                if ( skin == null )
-                    return;
-
-                Data.Blocks.Clear();
-                Data.Blocks.AddRange( skin.Blocks );
-
-                OnPropertyChanged( nameof( Data.Blocks ) );
-            }, Keys.None, CustomHandlerFlags.ClearMementos | CustomHandlerFlags.Repopulate );
 
             AddCustomHandler("Replace ex data from JSON", () =>
             {
@@ -263,6 +265,7 @@ namespace MikuMikuModel.Nodes.Objects
                 }
                 OnPropertyChanged(nameof(Data.Blocks));
             }, Keys.None, CustomHandlerFlags.ClearMementos | CustomHandlerFlags.Repopulate);
+
         }
 
         protected override void PopulateCore()


### PR DESCRIPTION
Added utilities to import and export ex data from a Skin node to and from JSON. Works exactly as ObjSet Skin ex data does right now. Additionally - 3ds Max sets Normal maps as Height, this alleviates that. Also allows Displacement maps from other 3d programs to be assigned as the Translucency slot for ease of material making.

<img width="615" alt="image" src="https://user-images.githubusercontent.com/46846973/184391272-a55767ea-d63d-4696-af98-4785473a6c27.png">
