### PR TITLE
Set OpenGL forward-compatible context

### DIFF
--- a/MikuMikuModel/GUI/Controls/ModelViewControl.cs
+++ b/MikuMikuModel/GUI/Controls/ModelViewControl.cs
@@ -734,7 +734,7 @@ public class ModelViewControl : GLControl
         Dispose(false);
     }
 
-    private ModelViewControl() : base(new GLControlSettings { NumberOfSamples = 2 })
+    private ModelViewControl() : base(new GLControlSettings { NumberOfSamples = 2, Flags = OpenTK.Windowing.Common.ContextFlags.ForwardCompatible })
     {
         MakeCurrent();
         


### PR DESCRIPTION
Makes the OpenGL context compatible with macOS, but removes support for wide lines.