### PR TITLE
Fix importing of skeletons

### DIFF
--- a/MikuMikuLibrary/Objects/Processing/Assimp/AssimpImporter.cs
+++ b/MikuMikuLibrary/Objects/Processing/Assimp/AssimpImporter.cs
@@ -140,7 +140,7 @@ public static class AssimpImporter
         Ai.Node parentNode = aiBoneNode.Parent;
         if (parentNode != null && !parentNode.HasMeshes && parentNode != aiScene.RootNode && (!aiScene.RootNode.Children.Contains(parentNode)))
         {
-            if (skin.GetBoneInfoByName(parentNode.Name) == null)
+            if (!skin.Bones.Any(x => x.Name == parentNode.Name))
             {
                 AddBoneToSkin(parentNode, skin);
 

--- a/MikuMikuModel/Nodes/Objects/ObjectNode.cs
+++ b/MikuMikuModel/Nodes/Objects/ObjectNode.cs
@@ -113,13 +113,9 @@ public class ObjectNode : Node<Object>
             else
                 return;
 
-            ushort baseID = 32770;
-
-            // fix bone orientations and assign IDs
+            // fix bone orientations 
             foreach (var bone in Data.Skin.Bones)
             {
-                bone.Id = baseID;
-                baseID++;
                 boneMap.TryGetValue(bone.Name, out var srcbonename);
                 var srcbone = baseObjectSet.Objects[0].Skin.Bones.FirstOrDefault(x => x.Name == srcbonename);
 

--- a/MikuMikuModel/Nodes/Objects/ObjectNode.cs
+++ b/MikuMikuModel/Nodes/Objects/ObjectNode.cs
@@ -113,10 +113,13 @@ public class ObjectNode : Node<Object>
             else
                 return;
 
+            ushort baseID = 32770;
 
-            // fix bone orientations
+            // fix bone orientations and assign IDs
             foreach (var bone in Data.Skin.Bones)
             {
+                bone.Id = baseID;
+                baseID++;
                 boneMap.TryGetValue(bone.Name, out var srcbonename);
                 var srcbone = baseObjectSet.Objects[0].Skin.Bones.FirstOrDefault(x => x.Name == srcbonename);
 


### PR DESCRIPTION
Due to the way assimp works, there's been a rather annoying issue in with only rigged bones would be imported as part of a model's skeleton. 

As a fix, instead of importing directly from each mesh's bones, it looks up each bone in the node tree, then walks to make sure the entire skeleton structure is correctly obtained and included. 

This serves the primary function of ensuring constraint creation works as expected, and also prevents any parts of models from snapping to origin as a result of unrigged helper bones. 

Additionally, every bone is given a default ID when constraints are being created, primarily to prevent any potential (albeit unlikely) loss of parenting.

Sorry for the potentially messy commit history, still learning git and some things went a little bit haywire...